### PR TITLE
Updating fleet-gitops to delete other teams not specified in the configs

### DIFF
--- a/.github/gitops-action/action.yml
+++ b/.github/gitops-action/action.yml
@@ -8,6 +8,9 @@ inputs:
   dry-run-only:
     description: 'Whether to only run the fleetctl gitops commands in dry-run mode.'
     default: 'false'
+  delete-other-teams:
+    description: 'Whether to delete other teams in Fleet which are not part of the gitops config.'
+    default: 'true'
 
 runs:
   using: "composite"
@@ -27,4 +30,5 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         FLEET_DRY_RUN_ONLY: ${{ inputs.dry-run-only }}
+        FLEET_DELETE_OTHER_TEAMS: ${{ inputs.delete-other-teams }}
       run: ./gitops.sh

--- a/gitops.sh
+++ b/gitops.sh
@@ -6,10 +6,11 @@
 # -o pipefail: Exit if any command in a pipeline fails.
 set -exuo pipefail
 
-FLEET_GITOPS_DIR="${FLEET_GITOPS_DIR:-./}"
+FLEET_GITOPS_DIR="${FLEET_GITOPS_DIR:-.}"
 FLEET_GLOBAL_FILE="${FLEET_GLOBAL_FILE:-$FLEET_GITOPS_DIR/default.yml}"
 FLEETCTL="${FLEETCTL:-fleetctl}"
 FLEET_DRY_RUN_ONLY="${FLEET_DRY_RUN_ONLY:-false}"
+FLEET_DELETE_OTHER_TEAMS="${FLEET_DELETE_OTHER_TEAMS:-true}"
 
 # Validate that global file contains org_settings
 grep -Exq "^org_settings:.*" "$FLEET_GLOBAL_FILE"
@@ -20,21 +21,19 @@ if compgen -G "$FLEET_GITOPS_DIR"/teams/*.yml > /dev/null; then
   ! perl -nle 'print $1 if /^name:\s*(.+)$/' "$FLEET_GITOPS_DIR"/teams/*.yml | sort | uniq -d | grep . -cq
 fi
 
-# Dry run
-$FLEETCTL gitops -f "$FLEET_GLOBAL_FILE" --dry-run
+args=(-f "$FLEET_GLOBAL_FILE")
 for team_file in "$FLEET_GITOPS_DIR"/teams/*.yml; do
-  if [ -f "$team_file" ]; then
-    $FLEETCTL gitops -f "$team_file" --dry-run
-  fi
+  args+=(-f "$team_file")
 done
+if [ "$FLEET_DELETE_OTHER_TEAMS" = true ]; then
+  args+=(--delete-other-teams)
+fi
+
+# Dry run
+$FLEETCTL gitops "${args[@]}" --dry-run
 if [ "$FLEET_DRY_RUN_ONLY" = true ]; then
   exit 0
 fi
 
 # Real run
-$FLEETCTL gitops -f "$FLEET_GLOBAL_FILE"
-for team_file in "$FLEET_GITOPS_DIR"/teams/*.yml; do
-  if [ -f "$team_file" ]; then
-    $FLEETCTL gitops -f "$team_file"
-  fi
-done
+$FLEETCTL gitops "${args[@]}"


### PR DESCRIPTION
Updating fleet-gitops to delete other teams not specified in the configs. Part of feature https://github.com/fleetdm/fleet/issues/16677

Dry run on dogfood: https://github.com/fleetdm/fleet/actions/runs/9275934450/job/25521787400
