### PR TITLE
Reapply "add top level software keys (#42)" (#43)

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -14,3 +14,4 @@ org_settings:
     org_name: Fleet
   secrets:
     - secret: "$FLEET_GLOBAL_ENROLL_SECRET"
+software:

--- a/teams/workstations-canary.yml
+++ b/teams/workstations-canary.yml
@@ -21,3 +21,4 @@ controls:
 team_settings:
   secrets:
     - secret: "$FLEET_WORKSTATIONS_CANARY_ENROLL_SECRET"
+software:

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -21,3 +21,4 @@ controls:
 team_settings:
   secrets:
     - secret: "$FLEET_WORKSTATIONS_ENROLL_SECRET"
+software:


### PR DESCRIPTION
This reverts commit d6a58007bb05db8a0cb823ff824aca863106856c.

Fleet's `main` now should work with `software:` key for "No team".