### PR TITLE
Match Fleet server version with fleetctl version

### DIFF
--- a/.github/gitops-action/action.yml
+++ b/.github/gitops-action/action.yml
@@ -19,8 +19,14 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        npm install -g fleetctl@$FLEET_VERSION
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
+
+        if [[ -n "$FLEET_VERSION" ]] ; then
+          npm install -g "fleetctl@$FLEET_VERSION"
+        else
+          echo "Failed to get Fleet version from $FLEET_URL, installing latest version of fleetctl"
+          npm install -g fleetctl
+        fi
 
     - name: Configure fleetctl
       shell: bash

--- a/.github/gitops-action/action.yml
+++ b/.github/gitops-action/action.yml
@@ -19,8 +19,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --silent | jq --raw-output '.version')"
         npm install -g fleetctl@$FLEET_VERSION
+        FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
 
     - name: Configure fleetctl
       shell: bash

--- a/.github/gitops-action/action.yml
+++ b/.github/gitops-action/action.yml
@@ -18,7 +18,9 @@ runs:
     - name: Install fleetctl
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: npm install -g fleetctl
+      run: |
+        FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --silent | jq --raw-output '.version')"
+        npm install -g fleetctl@$FLEET_VERSION
 
     - name: Configure fleetctl
       shell: bash


### PR DESCRIPTION
The provided GitHub Actions [workflow](https://github.com/fleetdm/fleet-gitops/blob/df3827abf0c5a73dd707cc10f513ca03d30769c0/.github/gitops-action/action.yml#L21) currently installs the latest version of `fleetctl` during each run, which can result in the workflow failing if this version does not match the server version you are targeting.

Here is an excerpt from an internal workflow run that failed to complete - the server version `4.54.1` was not aware of a key that was added in `fleetctl` version `4.55.0`: 

```shell
...
Warning: Version mismatch.
Client Version:   4.55.0
Server Version:  4.54.1
Error: applying fleet config: PATCH /api/latest/fleet/config received status 400 Bad Request: unsupported key provided: "ios_updates"
...
```

This PR attempts to correct this by determining the Fleet server-side version via the [/api/v1/fleet/version](https://fleetdm.com/docs/rest-api/rest-api#version) endpoint, and installing the correlating version of `fleetctl` during the GitHub workflow run.

**Assumptions:**

- `curl` - the workflow is configured to run on the [ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) GitHub runner image which has this dependency installed
- `jq` - the workflow is configured to run on the [ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) GitHub runner image which has this dependency installed