### PR TITLE
Fix Linux policy platform

### DIFF
--- a/lib/linux-device-health.policies.yml
+++ b/lib/linux-device-health.policies.yml
@@ -1,5 +1,5 @@
 - name: Linux - Enable disk encryption
-  platform: darwin
+  platform: linux
   description: This policy checks if disk encryption is enabled.
   resolution: As an IT admin, deploy an image that includes disk encryption.
   query: SELECT 1 FROM disk_encryption WHERE encrypted=1 AND name LIKE '/dev/dm-1';


### PR DESCRIPTION
Hopefully I am not getting ahead of myself here but I suspect the `platform` for the **Linux - Enable disk encryption** policy should be set to `linux`, otherwise the policy attempts to validate against Mac (`darwin`) hosts + fails.