### PR TITLE
Remove key from example declaration

### DIFF
--- a/lib/macos-os-updates.ddm.json
+++ b/lib/macos-os-updates.ddm.json
@@ -1,7 +1,6 @@
 {
   "Type": "com.apple.configuration.softwareupdate.enforcement.specific",
   "Identifier": "B6965621-36DF-46F6-839D-0F6591C9CA57",
-  "SeverToken": "20DD77EF-A359-4D63-87AA-30AFC916B261",
   "Payload": {
     "TargetOSVersion": "14.1",
     "TargetBuildVersion": "20A242",


### PR DESCRIPTION
The key ServerToken is misspelled in this example declaration. Also, it shouldn't be added manually. The MDM itself should be adding that in after hashing the contents to ensure that each change results in a different token.

This declaration also doesn't work as of today; fleetctl gitops will reject it because the macos_updates parameter is protected from DDM SUS profiles conflicting with it. I'm told that's a future feature, so maybe just comment this example file or remove it until then?

Thanks!