### PR TITLE
Add DDM sample profile

### DIFF
--- a/lib/macos-os-updates.ddm.json
+++ b/lib/macos-os-updates.ddm.json
@@ -1,9 +1,0 @@
-{
-  "Type": "com.apple.configuration.softwareupdate.enforcement.specific",
-  "Identifier": "B6965621-36DF-46F6-839D-0F6591C9CA57",
-  "Payload": {
-    "TargetOSVersion": "14.1",
-    "TargetBuildVersion": "20A242",
-    "TargetLocalDateTime": "2023-09-01T10:00:00" 
-  }
-}

--- a/lib/passcode-settings-ddm.json
+++ b/lib/passcode-settings-ddm.json
@@ -1,0 +1,10 @@
+{
+    "Type": "com.apple.configuration.passcode.settings",
+    "Identifier": "956e0d14-6019-479b-a6f9-a69ef77668c5",
+    "Payload": {
+        "MaximumFailedAttempts": 10,
+        "MaximumInactivityInMinutes": 5,
+        "MinimumLength": 12,
+        "MinimumComplexCharacters": 1
+    }
+}


### PR DESCRIPTION
Follow up PR from https://github.com/fleetdm/fleet-gitops/pull/47.

- Remove `lib/macos-os-updates.ddm.json` because Fleet doesn't allow the user to upload these OS update profiles.
- Add `lib/passcode-settings-ddm.json` as a sample DDM profile.