### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,5 +13,12 @@
 # - Historical context: https://github.com/fleetdm/fleet/pull/12786
 ##############################################################################################
 
-# Default owner
-* @getvictor
+# Best practice file structure
+/lib @harrisonravazzolo
+/teams @harrisonravazzolo
+default.yml @harrisonravazzolo
+
+# GitHub Action and GitLab CI/CD
+.github @getvictor
+.gitlab-ci.yml @getvictor
+gitops.sh @getvictor

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,3 +22,6 @@ default.yml @harrisonravazzolo
 .github @getvictor
 .gitlab-ci.yml @getvictor
 gitops.sh @getvictor
+
+# Everything else
+* @getvictor


### PR DESCRIPTION
- @harrisonravazzolo owns best practice file structure because it's used in GitOps training
- @getvictor owns GitHub/GitLab Action/CICD