### PR TITLE
By default, run GitOps every 24 hours

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch: # allows manual triggering
+  schedule:
+  - cron: '0 6 * * *' # Nightly 6AM UTC
 
 # Prevent concurrent runs of this workflow.
 concurrency:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,9 @@ fleet-gitops:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       variables:
         FLEET_DRY_RUN_ONLY: false
+    - if: $CI_PIPELINE_SOURCE == 'schedule' && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      variables:
+        FLEET_DRY_RUN_ONLY: false
   before_script:
     - apt-get -qq update
     - apt-get install -y jq=1.6-2.1

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ This is the starter repository for using [Fleet](https://fleetdm.com) with a Git
 
 5. Now, when anyone pushes a new commit to the default branch, the pipeline will run and update Fleet. For merge requests, the pipeline will do a dry run only.
 
+6. (Optional) To ensure your Fleet configuration stays up to date even when there are no new commits, set up a scheduled pipeline:
+   - In your GitLab project, go to the left sidebar and navigate to **Build > Pipeline schedules**. (In some GitLab versions, this may appear as **CI/CD > Schedules**.)
+   - Click **Create a new pipeline schedule** (or **Schedule a new pipeline**).
+   - Fill in the form:
+      - **Description**: e.g., `Daily GitOps sync`
+      - **Cron timezone**: e.g., `[UTC 0] UTC`
+      - **Interval pattern**: e.g., Custom: `0 6 * * *` (runs nightly at 6AM UTC)
+      - **Target branch or tag**: your default branch (e.g., `main`)
+   - Click **Create pipeline schedule**.
+
 ## Configuration options
 
 For all configuration options, go to the [YAML files reference](https://fleetdm.com/docs/using-fleet/gitops) in the Fleet docs.


### PR DESCRIPTION
Fleet already does this in Fleet's dogfood environment: https://github.com/fleetdm/fleet/blob/614376236a9b69ae9307398805acd065ddb60cac/.github/workflows/dogfood-gitops.yml#L15-L16

We learned that IT admins expect Fleet-maintained apps to update themselves. Fleet-maintained apps update on every GitOps run. More [context in Slack](https://fleetdm.slack.com/archives/C086V2QK76X/p1750949173486769?thread_ts=1750882925.073179&cid=C086V2QK76X).