### PR TITLE
Add repro for GitOps inline script backslash-escape stripping bug

### DIFF
--- a/lib/macos/scripts/repro-escape-bug-install.sh
+++ b/lib/macos/scripts/repro-escape-bug-install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Minimal repro for Fleet GitOps backslash-escape stripping bug.
+#
+# GitOps validation requires "$" to be escaped as "\$" so that Fleet does
+# not try to resolve "$VAR" as a repo-level environment variable at
+# validation time. The expectation is that Fleet strips the leading
+# backslash before delivering the script to the endpoint, so the host
+# receives a normal bash script containing "$EUID", "$USER", etc.
+#
+# If the delivered install script (visible in Fleet UI > Software >
+# this package > Advanced options > Install script) still contains
+# "\$EUID" / "\$USER" / "\$HOME" / "\$CURRENT_USER", the unescape step
+# is missing between GitOps ingestion and script delivery, and bash on
+# the target host will emit errors such as:
+#   line N: \$EUID: command not found
+#
+# Target: macOS workstation (self-service install).
+
+set -eu
+
+CURRENT_USER=$(/usr/bin/stat -f%Su /dev/console)
+
+echo "repro: EUID=\$EUID USER=\$USER HOME=\$HOME CURRENT_USER=\$CURRENT_USER"
+
+if [ "\$EUID" -ne 0 ]; then
+  echo "repro: not running as root (EUID=\$EUID)" >&2
+  exit 1
+fi
+
+echo "repro: invoking user is \$USER, console user is \$CURRENT_USER, home is \$HOME"
+exit 0

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -4,6 +4,20 @@ queries:
 agent_options:
 controls:
 software:
+  packages:
+    # Repro for Fleet GitOps backslash-escape stripping bug.
+    # A tiny, always-available macOS .pkg is used only as a carrier for
+    # the inline install script under lib/macos/scripts/repro-escape-bug-install.sh.
+    # The script contains escaped bash variables (\$EUID, \$USER, \$HOME,
+    # \$CURRENT_USER). Fleet GitOps validation rejects unescaped "$VAR"
+    # because it tries to resolve them as repo-level env vars, so the
+    # backslash escape is mandatory at ingestion time. The bug is that
+    # the backslash is still present when the install script is delivered
+    # to the host, causing shell errors on install.
+    - url: https://github.com/macadmins/installomator/releases/download/v10.7/Installomator-10.7.pkg
+      self_service: true
+      install_script:
+        path: ../lib/macos/scripts/repro-escape-bug-install.sh
 team_settings:
   secrets:
     - secret: "$FLEET_WORKSTATIONS_ENROLL_SECRET"


### PR DESCRIPTION
Adds a minimal macOS self-service package on the Workstations team that
references an inline install script containing common bash variables
(\$EUID, \$USER, \$HOME, \$CURRENT_USER) in their escaped form.

GitOps validation requires the backslash escape so Fleet does not try
to resolve these as repo-level environment variables at ingestion time.
The expectation is that Fleet strips the leading backslash before
delivering the script to the host. If the install script visible in
Fleet UI (Software > package > Advanced options > Install script) or
delivered at install time still contains the literal backslashes, the
unescape step is missing and bash on the target host will error out
with "\$EUID: command not found".

https://claude.ai/code/session_01BWXRyfu3TSmcG3bZfBjQnE