### PR TITLE
Bump DEFAULT_FLEETCTL_VERSION to 4.86.0

### DIFF
--- a/.github/gitops-action-fleets/action.yml
+++ b/.github/gitops-action-fleets/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         FLEET_URL="${FLEET_URL%/}"
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
-        DEFAULT_FLEETCTL_VERSION="4.85.1"
+        DEFAULT_FLEETCTL_VERSION="4.86.0"
 
         # Decide which fleetctl version to install:
         # If the server returns a clean version (e.g. 4.74.0), use that.

--- a/.github/gitops-action/action.yml
+++ b/.github/gitops-action/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         FLEET_URL="${FLEET_URL%/}"
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
-        DEFAULT_FLEETCTL_VERSION="4.85.1"
+        DEFAULT_FLEETCTL_VERSION="4.86.0"
 
         # Decide which fleetctl version to install:
         # If the server returns a clean version (e.g. 4.74.0), use that.


### PR DESCRIPTION
Release step 6: bump `DEFAULT_FLEETCTL_VERSION` from `4.85.1` to `4.86.0` in both gitops action workflows.

## Changes
- `.github/gitops-action/action.yml`
- `.github/gitops-action-fleets/action.yml`