### PR TITLE
Bump Fleet version to 4.87.0

### DIFF
--- a/.github/gitops-action-fleets/action.yml
+++ b/.github/gitops-action-fleets/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         FLEET_URL="${FLEET_URL%/}"
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
-        DEFAULT_FLEETCTL_VERSION="4.86.1"
+        DEFAULT_FLEETCTL_VERSION="4.87.0"
 
         # Decide which fleetctl version to install:
         # If the server returns a clean version (e.g. 4.74.0), use that.

--- a/.github/gitops-action/action.yml
+++ b/.github/gitops-action/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         FLEET_URL="${FLEET_URL%/}"
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
-        DEFAULT_FLEETCTL_VERSION="4.86.1"
+        DEFAULT_FLEETCTL_VERSION="4.87.0"
 
         # Decide which fleetctl version to install:
         # If the server returns a clean version (e.g. 4.74.0), use that.


### PR DESCRIPTION
Bumps `DEFAULT_FLEETCTL_VERSION` to `4.87.0` in the GitOps action definitions ahead of the Fleet 4.87.0 release.

## Changes
- `.github/gitops-action/action.yml`: `4.86.1` → `4.87.0`
- `.github/gitops-action-fleets/action.yml`: `4.86.1` → `4.87.0`