### PR TITLE
Bump Fleet version to v4.89.0

### DIFF
--- a/.github/gitops-action-fleets/action.yml
+++ b/.github/gitops-action-fleets/action.yml
@@ -32,7 +32,7 @@ runs:
         fi
 
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" "${CURL_HEADER_ARGS[@]}" --fail --silent | jq --raw-output '.version')"
-        DEFAULT_FLEETCTL_VERSION="4.88.1"
+        DEFAULT_FLEETCTL_VERSION="4.89.0"
 
         # Decide which fleetctl version to install:
         # If the server returns a clean version (e.g. 4.74.0), use that.

--- a/.github/gitops-action/action.yml
+++ b/.github/gitops-action/action.yml
@@ -32,7 +32,7 @@ runs:
         fi
 
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" "${CURL_HEADER_ARGS[@]}" --fail --silent | jq --raw-output '.version')"
-        DEFAULT_FLEETCTL_VERSION="4.88.1"
+        DEFAULT_FLEETCTL_VERSION="4.89.0"
 
         # Decide which fleetctl version to install:
         # If the server returns a clean version (e.g. 4.74.0), use that.


### PR DESCRIPTION
Bumps `DEFAULT_FLEETCTL_VERSION` from 4.88.1 to 4.89.0 in both gitops action definitions.

- `.github/gitops-action/action.yml`
- `.github/gitops-action-fleets/action.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)